### PR TITLE
アプリ化と諸修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -479,8 +479,15 @@
                         
                         appState.users = data.users || [];
                         appState.shifts = { ...appState.shifts, ...data.shifts };
+                        console.log('取得したデータ:', {
+                            shifts: data.shifts,
+                            manualBreaks: data.manualBreaks,
+                            manualShortages: data.manualShortages
+                        });
                         appState.manualBreaks = { ...appState.manualBreaks, ...data.manualBreaks };
                         appState.manualShortages = { ...appState.manualShortages, ...data.manualShortages };
+                        console.log('更新後のappState.manualBreaks:', appState.manualBreaks);
+                        console.log('更新後のappState.manualBreaksのキー:', Object.keys(appState.manualBreaks));
                         
                         loadedMonths[monthKey] = true;
                     } catch (error) {

--- a/index.html
+++ b/index.html
@@ -616,19 +616,24 @@
                 }
             }
             
-            // 保存処理の重複実行を防ぐためのフラグ
-            const savingFlags = new Set();
+            // 保存処理の重複実行を防ぐためのフラグとタイムスタンプ
+            const savingFlags = new Map(); // key: saveKey, value: timestamp
             
             async function handleBulkShiftChange(event) {
                 const input = event.target;
                 if (!input || !input.matches('input[type="text"]')) return;
                 
-                // 重複実行を防ぐ
+                // 重複実行を防ぐ（同じ入力フィールドで500ms以内の重複実行を防ぐ）
                 const saveKey = `${input.dataset.date}-${input.className}`;
-                if (savingFlags.has(saveKey)) {
-                    console.log('保存処理が既に実行中です:', saveKey);
+                const now = Date.now();
+                const lastSaveTime = savingFlags.get(saveKey);
+                
+                if (lastSaveTime && (now - lastSaveTime) < 500) {
+                    console.log('保存処理が既に実行中です（重複防止）:', saveKey);
                     return;
                 }
+                
+                savingFlags.set(saveKey, now);
 
                 // オートフォーマット & バリデーション（シフトセルと休憩時間入力）
                 if (input.matches('.bulk-cell')) {
@@ -663,8 +668,6 @@
                     console.log('シフト更新:', { userId, date, time });
                     success = await updateShift({ userId, date, time });
                 } else if (input.matches('.break-time-input') || input.matches('.shortage-input')) {
-                    savingFlags.add(saveKey);
-                    
                     const breakInput = mainViews.bulkShift.querySelector(`.break-time-input[data-date="${date}"]`);
                     const shortageInput = mainViews.bulkShift.querySelector(`.shortage-input[data-date="${date}"]`);
                     
@@ -684,7 +687,15 @@
                     console.log('休憩・不足時間更新:', { date, breaks, shortages });
                     success = await updateManualData(date, breaks, shortages);
                     
-                    savingFlags.delete(saveKey);
+                    // 保存完了後、少し遅延してからフラグをクリア（重複防止のため）
+                    setTimeout(() => {
+                        savingFlags.delete(saveKey);
+                    }, 1000);
+                } else {
+                    // シフト更新の場合もフラグをクリア
+                    setTimeout(() => {
+                        savingFlags.delete(saveKey);
+                    }, 1000);
                 }
                 
                 if(success) {
@@ -1051,9 +1062,17 @@
             // --- イベントリスナー設定 ---
             updateUserInfo();
             Object.keys(navButtons).forEach(key => navButtons[key].addEventListener('click', () => switchView(key)));
+            // changeイベントのみ使用（blurはchangeと重複するため削除）
             mainViews.bulkShift.addEventListener('change', handleBulkShiftChange);
-            mainViews.bulkShift.addEventListener('blur', handleBulkShiftChange, true); // blurイベントも追加（スマホ対応）
-            mainViews.bulkShift.addEventListener('keydown', handleBulkShiftKeyNavigation);
+            // スマホ対応：Enterキーで保存
+            mainViews.bulkShift.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' && e.target.matches('.break-time-input, .shortage-input')) {
+                    e.preventDefault();
+                    handleBulkShiftChange(e);
+                } else {
+                    handleBulkShiftKeyNavigation(e);
+                }
+            });
             mainViews.bulkShift.addEventListener('paste', handleBulkShiftPaste, true);
             document.getElementById('prevMonthBtn').addEventListener('click', () => { calendarDisplayDate.setMonth(calendarDisplayDate.getMonth() - 1); fetchDataForMonth(calendarDisplayDate); });
             document.getElementById('nextMonthBtn').addEventListener('click', () => { calendarDisplayDate.setMonth(calendarDisplayDate.getMonth() + 1); fetchDataForMonth(calendarDisplayDate); });

--- a/index.html
+++ b/index.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>31shiftシステム</title>
+    <!-- PWA Meta Tags -->
+    <meta name="theme-color" content="#4f46e5">
+    <meta name="description" content="シフト管理システム">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
+    <meta name="apple-mobile-web-app-title" content="31shift">
+    <link rel="apple-touch-icon" href="img/icon.png">
+    <link rel="manifest" href="manifest.json">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
@@ -875,6 +883,19 @@
             switchView('calendar');
         }
     });
+
+    // --- Service Worker登録 ---
+    if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+            navigator.serviceWorker.register('/service-worker.js')
+                .then((registration) => {
+                    console.log('Service Worker登録成功:', registration.scope);
+                })
+                .catch((error) => {
+                    console.log('Service Worker登録失敗:', error);
+                });
+        });
+    }
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -466,12 +466,12 @@
             }
             
             // --- Data Fetching & State ---
-            async function fetchDataForMonth(date) {
+            async function fetchDataForMonth(date, forceRefresh = false) {
                 const year = date.getFullYear();
                 const month = ('0' + (date.getMonth() + 1)).slice(-2);
                 const monthKey = `${year}-${month}`;
                 
-                if (!loadedMonths[monthKey]) {
+                if (!loadedMonths[monthKey] || forceRefresh) {
                     try {
                         const response = await fetch(`${API_BASE_URL}/api/data?month=${year}-${month}`);
                         if (!response.ok) throw new Error('API Error');
@@ -585,6 +585,14 @@
                     appState.manualBreaks[date] = breaks;
                     appState.manualShortages[date] = shortages;
                     
+                    // データを再取得して最新状態を反映（キャッシュをクリア）
+                    const dateObj = new Date(date + 'T00:00:00');
+                    const monthKey = `${dateObj.getFullYear()}-${('0' + (dateObj.getMonth() + 1)).slice(-2)}`;
+                    if (loadedMonths[monthKey]) {
+                        loadedMonths[monthKey] = false; // キャッシュをクリア
+                    }
+                    await fetchDataForMonth(dateObj, true); // 強制再取得
+                    
                     console.log('ローカル状態更新完了:', { breaks: appState.manualBreaks[date], shortages: appState.manualShortages[date] });
                     return true;
                 } catch (error) {
@@ -624,7 +632,18 @@
                 } else if (input.matches('.break-time-input') || input.matches('.shortage-input')) {
                     const breakInput = mainViews.bulkShift.querySelector(`.break-time-input[data-date="${date}"]`);
                     const shortageInput = mainViews.bulkShift.querySelector(`.shortage-input[data-date="${date}"]`);
-                    const breaks = breakInput ? breakInput.value.trim() : '';
+                    
+                    // 休憩時間は正規化された値を保存
+                    let breaks = breakInput ? breakInput.value.trim() : '';
+                    if (breaks && breakInput) {
+                        // 再度正規化してから保存（念のため）
+                        const normalized = normalizeShiftTimeInput(breaks);
+                        if (normalized !== breaks) {
+                            breakInput.value = normalized;
+                            breaks = normalized;
+                        }
+                    }
+                    
                     const shortages = shortageInput ? shortageInput.value.trim() : '';
                     success = await updateManualData(date, breaks, shortages);
                 }

--- a/index.html
+++ b/index.html
@@ -363,25 +363,61 @@
                 d.setHours(h, m, 0, 0);
                 return d;
             }
-            // 休憩時間を分単位に変換する関数（「60分」「1時間」「60」「1:00」などの形式に対応）
-            function parseBreakTimeToMinutes(breakTimeStr) {
-                if (!breakTimeStr || !breakTimeStr.trim()) return 0;
+            // 休憩時間を解析する関数（時間範囲形式「17:00-18:00」に対応）
+            function parseBreakTime(breakTimeStr, baseDate) {
+                if (!breakTimeStr || !breakTimeStr.trim()) return null;
                 const str = breakTimeStr.trim();
+                
+                // 時間範囲形式（例：「17:00-18:00」）をチェック
+                if (str.includes(' - ') || str.includes('-')) {
+                    const normalized = normalizeShiftTimeInput(str);
+                    if (normalized && normalized.includes(' - ')) {
+                        const [startStr, endStr] = normalized.split(' - ');
+                        const startDate = parseTimeToDate(startStr.trim(), baseDate);
+                        const endDate = parseTimeToDate(endStr.trim(), baseDate);
+                        if (startDate && endDate) {
+                            return {
+                                start: startDate,
+                                end: endDate,
+                                minutes: (endDate - startDate) / (1000 * 60)
+                            };
+                        }
+                    }
+                }
+                
+                // 旧形式のサポート（後方互換性のため）
                 // 「分」を削除
                 const withoutUnit = str.replace(/分/g, '').trim();
                 // 「時間」を分に変換
                 if (withoutUnit.includes('時間')) {
                     const [hours, minutes] = withoutUnit.split('時間').map(s => parseInt(s.trim()) || 0);
-                    return hours * 60 + (minutes || 0);
+                    const totalMinutes = hours * 60 + (minutes || 0);
+                    return {
+                        start: null,
+                        end: null,
+                        minutes: totalMinutes
+                    };
                 }
-                // 「:」が含まれている場合（例：「1:00」）
-                if (withoutUnit.includes(':')) {
+                // 「:」が含まれている場合（例：「1:00」）- これは時間の長さとして扱う
+                if (withoutUnit.includes(':') && !withoutUnit.includes('-')) {
                     const [h, m] = withoutUnit.split(':').map(s => parseInt(s.trim()) || 0);
-                    return h * 60 + m;
+                    return {
+                        start: null,
+                        end: null,
+                        minutes: h * 60 + m
+                    };
                 }
-                // 数値のみの場合（例：「60」）
+                // 数値のみの場合（例：「60」）- 分単位として扱う
                 const num = parseInt(withoutUnit);
-                return isNaN(num) ? 0 : num;
+                if (!isNaN(num)) {
+                    return {
+                        start: null,
+                        end: null,
+                        minutes: num
+                    };
+                }
+                
+                return null;
             }
             function isValidShiftTimeFormat(str) {
                 if (!str) return true;
@@ -562,7 +598,7 @@
                 const input = event.target;
                 if (!input.matches('input[type="text"]')) return;
 
-                // オートフォーマット & バリデーション（シフトセルのみ）
+                // オートフォーマット & バリデーション（シフトセルと休憩時間入力）
                 if (input.matches('.bulk-cell')) {
                     const normalized = normalizeShiftTimeInput(input.value);
                     if (normalized !== input.value) input.value = normalized;
@@ -572,6 +608,10 @@
                     } else {
                         input.style.outline = '';
                     }
+                } else if (input.matches('.break-time-input')) {
+                    // 休憩時間入力もシフト時間と同じ形式で正規化
+                    const normalized = normalizeShiftTimeInput(input.value);
+                    if (normalized !== input.value) input.value = normalized;
                 }
 
                 const date = input.dataset.date;
@@ -761,7 +801,7 @@
                 
                 // 休憩時間を取得
                 const breakTimeStr = appState.manualBreaks[dateString] || '';
-                const breakMinutes = parseBreakTimeToMinutes(breakTimeStr);
+                const breakTimeInfo = parseBreakTime(breakTimeStr, chartDisplayDate);
 
                 // グラフデータを生成（休憩時間を考慮）
                 const chartDatasetData = [];
@@ -775,10 +815,18 @@
                     const workMinutes = (mainEndDate - mainStartDate) / (1000 * 60);
                     
                     // 7時間（420分）を超える場合、かつ休憩時間が入力されている場合のみ休憩を適用
-                    if (workMinutes > 420 && breakMinutes > 0) {
-                        // 休憩開始時間（勤務時間の中央付近）
-                        const breakStartDate = new Date(mainStartDate.getTime() + (workMinutes - breakMinutes) / 2 * 60 * 1000);
-                        const breakEndDate = new Date(breakStartDate.getTime() + breakMinutes * 60 * 1000);
+                    if (workMinutes > 420 && breakTimeInfo && breakTimeInfo.minutes > 0) {
+                        let breakStartDate, breakEndDate;
+                        
+                        // 時間範囲形式の場合（開始時刻・終了時刻が指定されている）
+                        if (breakTimeInfo.start && breakTimeInfo.end) {
+                            breakStartDate = breakTimeInfo.start;
+                            breakEndDate = breakTimeInfo.end;
+                        } else {
+                            // 旧形式（分単位のみ）の場合、勤務時間の中央付近に配置
+                            breakStartDate = new Date(mainStartDate.getTime() + (workMinutes - breakTimeInfo.minutes) / 2 * 60 * 1000);
+                            breakEndDate = new Date(breakStartDate.getTime() + breakTimeInfo.minutes * 60 * 1000);
+                        }
                         
                         // 勤務時間を2つに分割
                         // 1. 開始から休憩開始まで

--- a/index.html
+++ b/index.html
@@ -363,6 +363,26 @@
                 d.setHours(h, m, 0, 0);
                 return d;
             }
+            // 休憩時間を分単位に変換する関数（「60分」「1時間」「60」「1:00」などの形式に対応）
+            function parseBreakTimeToMinutes(breakTimeStr) {
+                if (!breakTimeStr || !breakTimeStr.trim()) return 0;
+                const str = breakTimeStr.trim();
+                // 「分」を削除
+                const withoutUnit = str.replace(/分/g, '').trim();
+                // 「時間」を分に変換
+                if (withoutUnit.includes('時間')) {
+                    const [hours, minutes] = withoutUnit.split('時間').map(s => parseInt(s.trim()) || 0);
+                    return hours * 60 + (minutes || 0);
+                }
+                // 「:」が含まれている場合（例：「1:00」）
+                if (withoutUnit.includes(':')) {
+                    const [h, m] = withoutUnit.split(':').map(s => parseInt(s.trim()) || 0);
+                    return h * 60 + m;
+                }
+                // 数値のみの場合（例：「60」）
+                const num = parseInt(withoutUnit);
+                return isNaN(num) ? 0 : num;
+            }
             function isValidShiftTimeFormat(str) {
                 if (!str) return true;
                 return /^\d{2}:\d{2}\s*-\s*\d{2}:\d{2}$/.test(str.trim());
@@ -738,17 +758,57 @@
                     });
 
                 const yLabels = sortedShifts.map(s => s.fullName);
+                
+                // 休憩時間を取得
+                const breakTimeStr = appState.manualBreaks[dateString] || '';
+                const breakMinutes = parseBreakTimeToMinutes(breakTimeStr);
 
-                const chartDatasetData = sortedShifts.map(shift => {
+                // グラフデータを生成（休憩時間を考慮）
+                const chartDatasetData = [];
+                sortedShifts.forEach(shift => {
                     const [startStr, endStr] = shift.time.split(' - ');
                     const mainStartDate = parseTimeToDate(startStr, chartDisplayDate);
                     const mainEndDate = parseTimeToDate(endStr, chartDisplayDate);
-                    if(!mainStartDate || !mainEndDate) return null;
-                    return {
-                        x: [mainStartDate.getTime(), mainEndDate.getTime()], y: shift.fullName, originalShift: shift,
-                        bgColor: shift.role === 'manager' ? 'rgba(250, 204, 21, 0.7)' : 'rgba(59, 130, 246, 0.7)'
-                    };
-                }).filter(Boolean);
+                    if(!mainStartDate || !mainEndDate) return;
+                    
+                    // 勤務時間を分単位で計算
+                    const workMinutes = (mainEndDate - mainStartDate) / (1000 * 60);
+                    
+                    // 7時間（420分）を超える場合、かつ休憩時間が入力されている場合のみ休憩を適用
+                    if (workMinutes > 420 && breakMinutes > 0) {
+                        // 休憩開始時間（勤務時間の中央付近）
+                        const breakStartDate = new Date(mainStartDate.getTime() + (workMinutes - breakMinutes) / 2 * 60 * 1000);
+                        const breakEndDate = new Date(breakStartDate.getTime() + breakMinutes * 60 * 1000);
+                        
+                        // 勤務時間を2つに分割
+                        // 1. 開始から休憩開始まで
+                        chartDatasetData.push({
+                            x: [mainStartDate.getTime(), breakStartDate.getTime()],
+                            y: shift.fullName,
+                            originalShift: shift,
+                            bgColor: shift.role === 'manager' ? 'rgba(250, 204, 21, 0.7)' : 'rgba(59, 130, 246, 0.7)',
+                            isBreak: false
+                        });
+                        
+                        // 2. 休憩終了から終了まで
+                        chartDatasetData.push({
+                            x: [breakEndDate.getTime(), mainEndDate.getTime()],
+                            y: shift.fullName,
+                            originalShift: shift,
+                            bgColor: shift.role === 'manager' ? 'rgba(250, 204, 21, 0.7)' : 'rgba(59, 130, 246, 0.7)',
+                            isBreak: false
+                        });
+                    } else {
+                        // 休憩を適用しない場合（通常の表示）
+                        chartDatasetData.push({
+                            x: [mainStartDate.getTime(), mainEndDate.getTime()],
+                            y: shift.fullName,
+                            originalShift: shift,
+                            bgColor: shift.role === 'manager' ? 'rgba(250, 204, 21, 0.7)' : 'rgba(59, 130, 246, 0.7)',
+                            isBreak: false
+                        });
+                    }
+                });
                 
                 const chartMinTime = new Date(chartDisplayDate); chartMinTime.setHours(9,0,0,0); 
                 const chartMaxTime = new Date(chartDisplayDate); chartMaxTime.setHours(21,0,0,0); 
@@ -771,7 +831,14 @@
                                     label: function(context) {
                                         const start = new Date(context.raw.x[0]);
                                         const end = new Date(context.raw.x[1]);
-                                        return `${context.raw.originalShift.fullName}: ${formatTime(start)} - ${formatTime(end)}`;
+                                        const workMinutes = (end - start) / (1000 * 60);
+                                        const hours = Math.floor(workMinutes / 60);
+                                        const minutes = workMinutes % 60;
+                                        let label = `${context.raw.originalShift.fullName}: ${formatTime(start)} - ${formatTime(end)}`;
+                                        if (hours > 0 || minutes > 0) {
+                                            label += ` (${hours}時間${minutes > 0 ? minutes + '分' : ''})`;
+                                        }
+                                        return label;
                                     }
                                 }
                             }
@@ -807,7 +874,12 @@
                 }
                 dateHeader.innerHTML = headerHtml;
                 
-                const displayableUsers = [...appState.users];
+                // managerを上位に表示するようにソート
+                const displayableUsers = [...appState.users].sort((a, b) => {
+                    if (a.role === 'manager' && b.role !== 'manager') return -1;
+                    if (a.role !== 'manager' && b.role === 'manager') return 1;
+                    return 0; // 同じroleの場合は元の順序を維持
+                });
                 displayableUsers.forEach(user => {
                     let rowHtml = `<tr><th class="font-semibold p-2 text-left whitespace-nowrap ${user.role === 'manager' ? 'text-amber-700' : ''}">${user.name}</th>`;
                     days.forEach((dateString) => {

--- a/index.html
+++ b/index.html
@@ -101,6 +101,14 @@
         .bulk-shift-table tfoot th { background-color: var(--bg-accent); position: sticky; left: 0; z-index: 10;}
         .bulk-shift-table input[type="text"] { border: none; }
         
+        /* 入力フィールドのフォントサイズ設定（通常時は小さく、フォーカス時は16px以上） */
+        .bulk-shift-table input[type="text"] {
+            font-size: 0.875rem; /* 14px - 通常時 */
+        }
+        .bulk-shift-table input[type="text"]:focus {
+            font-size: 1rem !important; /* 16px - フォーカス時は16px以上でズームを防ぐ */
+        }
+        
         /* スマホ対応の一括シフトテーブル */
         @media (max-width: 768px) {
             .bulk-shift-table {
@@ -111,9 +119,12 @@
                 min-width: 100px;
             }
             .bulk-shift-table input[type="text"] {
-                font-size: 1rem; /* 16px以上にしてズームを防ぐ */
+                font-size: 0.75rem; /* 12px - 通常時は小さく */
                 padding: 0.2rem;
                 min-width: 95px;
+            }
+            .bulk-shift-table input[type="text"]:focus {
+                font-size: 1rem !important; /* 16px - フォーカス時は16px以上でズームを防ぐ */
             }
             .bulk-shift-table tbody th {
                 min-width: 110px;
@@ -131,9 +142,12 @@
                 min-width: 120px;
             }
             .bulk-shift-table input[type="text"] {
-                font-size: 1rem; /* 16px以上にしてズームを防ぐ */
+                font-size: 0.875rem; /* 14px - 通常時 */
                 padding: 0.3rem;
                 min-width: 115px;
+            }
+            .bulk-shift-table input[type="text"]:focus {
+                font-size: 1rem !important; /* 16px - フォーカス時は16px以上でズームを防ぐ */
             }
         }
         
@@ -798,7 +812,7 @@
                     let rowHtml = `<tr><th class="font-semibold p-2 text-left whitespace-nowrap ${user.role === 'manager' ? 'text-amber-700' : ''}">${user.name}</th>`;
                     days.forEach((dateString) => {
                         const shift = (appState.shifts[dateString] || []).find(s => s.userId === user.id);
-                        rowHtml += `<td class="p-0"><input type="text" value="${shift && shift.time && shift.time.trim() ? shift.time : ""}" data-user-id="${user.id}" data-date="${dateString}" class="bulk-cell w-full h-full p-2 bg-transparent border-t-0 border-b-0 border-l-0 border-r text-center" style="border-color: var(--border-color); font-size: 1rem;" placeholder=" " inputmode="numeric" autocomplete="off"></td>`;
+                        rowHtml += `<td class="p-0"><input type="text" value="${shift && shift.time && shift.time.trim() ? shift.time : ""}" data-user-id="${user.id}" data-date="${dateString}" class="bulk-cell w-full h-full p-2 bg-transparent border-t-0 border-b-0 border-l-0 border-r text-center" style="border-color: var(--border-color);" placeholder=" " inputmode="numeric" autocomplete="off"></td>`;
                     });
                     rowHtml += '</tr>';
                     body.innerHTML += rowHtml;
@@ -807,14 +821,14 @@
                 let breakTimesRowHtml = '<tr><th class="font-semibold p-2 text-left">休憩</th>'; 
                 days.forEach(dateString => {
                     const breakValue = appState.manualBreaks[dateString];
-                    breakTimesRowHtml += `<td class="p-0"><input type="text" class="break-time-input w-full h-full p-2 bg-transparent border-t-0 border-b-0 border-l-0 border-r text-center" value="${breakValue && breakValue.trim() ? breakValue : ''}" data-date="${dateString}" style="border-color: var(--border-color); font-size: 1rem;" placeholder=" "></td>`;
+                    breakTimesRowHtml += `<td class="p-0"><input type="text" class="break-time-input w-full h-full p-2 bg-transparent border-t-0 border-b-0 border-l-0 border-r text-center" value="${breakValue && breakValue.trim() ? breakValue : ''}" data-date="${dateString}" style="border-color: var(--border-color);" placeholder=" "></td>`;
                 });
                 breakRow.innerHTML = breakTimesRowHtml;
 
                 let shortageRowHtml = '<tr><th class="font-semibold p-2 text-left">不足</th>'; 
                 days.forEach(dateString => {
                     const shortageValue = appState.manualShortages[dateString];
-                    shortageRowHtml += `<td class="p-0"><input type="text" class="shortage-input w-full h-full p-2 bg-transparent border-t-0 border-b-0 border-l-0 border-r text-center" value="${shortageValue && shortageValue.trim() ? shortageValue : ''}" data-date="${dateString}" style="border-color: var(--border-color); font-size: 1rem;" placeholder=" "></td>`;
+                    shortageRowHtml += `<td class="p-0"><input type="text" class="shortage-input w-full h-full p-2 bg-transparent border-t-0 border-b-0 border-l-0 border-r text-center" value="${shortageValue && shortageValue.trim() ? shortageValue : ''}" data-date="${dateString}" style="border-color: var(--border-color);" placeholder=" "></td>`;
                 });
                 shortageRow.innerHTML = shortageRowHtml;
 

--- a/index.html
+++ b/index.html
@@ -589,6 +589,17 @@
                     const result = await response.json();
                     console.log('API成功レスポンス:', result);
                     
+                    // APIレスポンスにエラーが含まれている場合
+                    if (result.success === false || result.error) {
+                        console.error('APIからエラーが返されました:', result);
+                        throw new Error(result.error || result.message || 'APIエラーが発生しました');
+                    }
+                    
+                    // 保存されたデータを確認
+                    if (result.breaks !== undefined) {
+                        console.log('APIから返された休憩時間:', result.breaks);
+                    }
+                    
                     // ローカル状態を更新（空の文字列も保存）
                     appState.manualBreaks[date] = breaks || '';
                     appState.manualShortages[date] = shortages || '';
@@ -606,6 +617,9 @@
                         loadedMonths[monthKey] = false; // キャッシュをクリア
                     }
                     await fetchDataForMonth(dateObj, true); // 強制再取得
+                    
+                    // 再取得後のデータを確認
+                    console.log('再取得後の休憩時間データ:', appState.manualBreaks[date]);
                     
                     console.log('ローカル状態更新完了:', { breaks: appState.manualBreaks[date], shortages: appState.manualShortages[date] });
                     return true;

--- a/index.html
+++ b/index.html
@@ -556,7 +556,7 @@
             
             async function updateManualData(date, breaks, shortages) {
                 try {
-                    console.log('手動データ更新リクエスト:', { date, breaks, shortages });
+                    console.log('手動データ更新リクエスト:', { date, breaks, shortages, breaksType: typeof breaks, breaksLength: breaks ? breaks.length : 0 });
                     
                     // データの検証
                     if (!date) {
@@ -564,10 +564,18 @@
                         throw new Error('日付が不足しています');
                     }
                     
+                    // 空の文字列も明示的に送信（削除のため）
+                    const requestBody = { 
+                        date, 
+                        breaks: breaks || '', 
+                        shortages: shortages || '' 
+                    };
+                    console.log('送信するデータ:', JSON.stringify(requestBody));
+                    
                     const response = await fetch(`${API_BASE_URL}/api/update-manual-data`, {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ date, breaks, shortages })
+                        body: JSON.stringify(requestBody)
                     });
                     
                     console.log('APIレスポンス:', response.status, response.statusText);
@@ -581,9 +589,15 @@
                     const result = await response.json();
                     console.log('API成功レスポンス:', result);
                     
-                    // ローカル状態を更新
-                    appState.manualBreaks[date] = breaks;
-                    appState.manualShortages[date] = shortages;
+                    // ローカル状態を更新（空の文字列も保存）
+                    appState.manualBreaks[date] = breaks || '';
+                    appState.manualShortages[date] = shortages || '';
+                    
+                    console.log('ローカル状態を更新:', { 
+                        date, 
+                        breaks: appState.manualBreaks[date], 
+                        shortages: appState.manualShortages[date] 
+                    });
                     
                     // データを再取得して最新状態を反映（キャッシュをクリア）
                     const dateObj = new Date(date + 'T00:00:00');
@@ -602,9 +616,19 @@
                 }
             }
             
+            // 保存処理の重複実行を防ぐためのフラグ
+            const savingFlags = new Set();
+            
             async function handleBulkShiftChange(event) {
                 const input = event.target;
-                if (!input.matches('input[type="text"]')) return;
+                if (!input || !input.matches('input[type="text"]')) return;
+                
+                // 重複実行を防ぐ
+                const saveKey = `${input.dataset.date}-${input.className}`;
+                if (savingFlags.has(saveKey)) {
+                    console.log('保存処理が既に実行中です:', saveKey);
+                    return;
+                }
 
                 // オートフォーマット & バリデーション（シフトセルと休憩時間入力）
                 if (input.matches('.bulk-cell')) {
@@ -619,17 +643,28 @@
                 } else if (input.matches('.break-time-input')) {
                     // 休憩時間入力もシフト時間と同じ形式で正規化
                     const normalized = normalizeShiftTimeInput(input.value);
-                    if (normalized !== input.value) input.value = normalized;
+                    if (normalized !== input.value) {
+                        input.value = normalized;
+                        console.log('休憩時間を正規化:', input.value, '→', normalized);
+                    }
                 }
 
                 const date = input.dataset.date;
+                if (!date) {
+                    console.error('日付が取得できません:', input);
+                    return;
+                }
+                
                 let success = false;
                 
                 if (input.matches('input[data-user-id]')) {
                     const userId = parseInt(input.dataset.userId, 10);
                     const time = input.value.trim();
+                    console.log('シフト更新:', { userId, date, time });
                     success = await updateShift({ userId, date, time });
                 } else if (input.matches('.break-time-input') || input.matches('.shortage-input')) {
+                    savingFlags.add(saveKey);
+                    
                     const breakInput = mainViews.bulkShift.querySelector(`.break-time-input[data-date="${date}"]`);
                     const shortageInput = mainViews.bulkShift.querySelector(`.shortage-input[data-date="${date}"]`);
                     
@@ -645,7 +680,11 @@
                     }
                     
                     const shortages = shortageInput ? shortageInput.value.trim() : '';
+                    
+                    console.log('休憩・不足時間更新:', { date, breaks, shortages });
                     success = await updateManualData(date, breaks, shortages);
+                    
+                    savingFlags.delete(saveKey);
                 }
                 
                 if(success) {
@@ -1013,6 +1052,7 @@
             updateUserInfo();
             Object.keys(navButtons).forEach(key => navButtons[key].addEventListener('click', () => switchView(key)));
             mainViews.bulkShift.addEventListener('change', handleBulkShiftChange);
+            mainViews.bulkShift.addEventListener('blur', handleBulkShiftChange, true); // blurイベントも追加（スマホ対応）
             mainViews.bulkShift.addEventListener('keydown', handleBulkShiftKeyNavigation);
             mainViews.bulkShift.addEventListener('paste', handleBulkShiftPaste, true);
             document.getElementById('prevMonthBtn').addEventListener('click', () => { calendarDisplayDate.setMonth(calendarDisplayDate.getMonth() - 1); fetchDataForMonth(calendarDisplayDate); });

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
     <title>31shiftシステム</title>
     <!-- PWA Meta Tags -->
     <meta name="theme-color" content="#4f46e5">
@@ -111,7 +111,7 @@
                 min-width: 100px;
             }
             .bulk-shift-table input[type="text"] {
-                font-size: 0.7rem;
+                font-size: 1rem; /* 16px以上にしてズームを防ぐ */
                 padding: 0.2rem;
                 min-width: 95px;
             }
@@ -131,7 +131,7 @@
                 min-width: 120px;
             }
             .bulk-shift-table input[type="text"] {
-                font-size: 0.8rem;
+                font-size: 1rem; /* 16px以上にしてズームを防ぐ */
                 padding: 0.3rem;
                 min-width: 115px;
             }
@@ -798,7 +798,7 @@
                     let rowHtml = `<tr><th class="font-semibold p-2 text-left whitespace-nowrap ${user.role === 'manager' ? 'text-amber-700' : ''}">${user.name}</th>`;
                     days.forEach((dateString) => {
                         const shift = (appState.shifts[dateString] || []).find(s => s.userId === user.id);
-                        rowHtml += `<td class="p-0"><input type="text" value="${shift && shift.time && shift.time.trim() ? shift.time : ""}" data-user-id="${user.id}" data-date="${dateString}" class="bulk-cell w-full h-full p-2 bg-transparent border-t-0 border-b-0 border-l-0 border-r text-center text-sm" style="border-color: var(--border-color);" placeholder=" " inputmode="numeric" autocomplete="off"></td>`;
+                        rowHtml += `<td class="p-0"><input type="text" value="${shift && shift.time && shift.time.trim() ? shift.time : ""}" data-user-id="${user.id}" data-date="${dateString}" class="bulk-cell w-full h-full p-2 bg-transparent border-t-0 border-b-0 border-l-0 border-r text-center" style="border-color: var(--border-color); font-size: 1rem;" placeholder=" " inputmode="numeric" autocomplete="off"></td>`;
                     });
                     rowHtml += '</tr>';
                     body.innerHTML += rowHtml;
@@ -807,14 +807,14 @@
                 let breakTimesRowHtml = '<tr><th class="font-semibold p-2 text-left">休憩</th>'; 
                 days.forEach(dateString => {
                     const breakValue = appState.manualBreaks[dateString];
-                    breakTimesRowHtml += `<td class="p-0"><input type="text" class="break-time-input w-full h-full p-2 bg-transparent border-t-0 border-b-0 border-l-0 border-r text-center text-sm" value="${breakValue && breakValue.trim() ? breakValue : ''}" data-date="${dateString}" style="border-color: var(--border-color);" placeholder=" "></td>`;
+                    breakTimesRowHtml += `<td class="p-0"><input type="text" class="break-time-input w-full h-full p-2 bg-transparent border-t-0 border-b-0 border-l-0 border-r text-center" value="${breakValue && breakValue.trim() ? breakValue : ''}" data-date="${dateString}" style="border-color: var(--border-color); font-size: 1rem;" placeholder=" "></td>`;
                 });
                 breakRow.innerHTML = breakTimesRowHtml;
 
                 let shortageRowHtml = '<tr><th class="font-semibold p-2 text-left">不足</th>'; 
                 days.forEach(dateString => {
                     const shortageValue = appState.manualShortages[dateString];
-                    shortageRowHtml += `<td class="p-0"><input type="text" class="shortage-input w-full h-full p-2 bg-transparent border-t-0 border-b-0 border-l-0 border-r text-center text-sm" value="${shortageValue && shortageValue.trim() ? shortageValue : ''}" data-date="${dateString}" style="border-color: var(--border-color);" placeholder=" "></td>`;
+                    shortageRowHtml += `<td class="p-0"><input type="text" class="shortage-input w-full h-full p-2 bg-transparent border-t-0 border-b-0 border-l-0 border-r text-center" value="${shortageValue && shortageValue.trim() ? shortageValue : ''}" data-date="${dateString}" style="border-color: var(--border-color); font-size: 1rem;" placeholder=" "></td>`;
                 });
                 shortageRow.innerHTML = shortageRowHtml;
 

--- a/index.html
+++ b/index.html
@@ -1016,7 +1016,8 @@
                 const displayableUsers = [...appState.users].sort((a, b) => {
                     if (a.role === 'manager' && b.role !== 'manager') return -1;
                     if (a.role !== 'manager' && b.role === 'manager') return 1;
-                    return 0; // 同じroleの場合は元の順序を維持
+                    // 同じrole内ではIDの昇順
+                    return (a.id ?? 0) - (b.id ?? 0);
                 });
                 displayableUsers.forEach(user => {
                     let rowHtml = `<tr><th class="font-semibold p-2 text-left whitespace-nowrap ${user.role === 'manager' ? 'text-amber-700' : ''}">${user.name}</th>`;

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,27 @@
+{
+  "name": "31shiftシステム",
+  "short_name": "31shift",
+  "description": "シフト管理システム",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#f8fafc",
+  "theme_color": "#4f46e5",
+  "orientation": "portrait-primary",
+  "icons": [
+    {
+      "src": "img/icon.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "img/icon.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ],
+  "categories": ["business", "productivity"],
+  "lang": "ja"
+}
+

--- a/my-shift-backend/src/index.ts
+++ b/my-shift-backend/src/index.ts
@@ -38,12 +38,18 @@ export default {
 
                 const shiftsStmt = env.DB.prepare(`
                     SELECT 
-                        s.id, s.user_id as userId, u.name as fullName, u.role, 
-                        s.shift_date as shiftDate, s.time, s.break_time as breakTime, s.notes 
+                        s.id, s.user_id as userId, 
+                        COALESCE(u.name, '') as fullName, 
+                        COALESCE(u.role, '') as role, 
+                        s.shift_date as shiftDate, 
+                        s.time, 
+                        s.break_time as breakTime, 
+                        s.notes 
                     FROM 
                         shifts s LEFT JOIN users u ON s.user_id = u.id 
                     WHERE 
                         strftime('%Y-%m', s.shift_date) = ?
+                    ORDER BY s.shift_date, s.user_id
                 `).bind(month);
                 
                 const usersStmt = env.DB.prepare('SELECT * FROM users ORDER BY id');
@@ -67,10 +73,14 @@ export default {
                     const date = shift.shiftDate as string;
                     // 同じ日付で最初に見つかったbreak_timeを使用（全レコードで同じ値のはず）
                     // user_id=0のダミーレコードも含める
-                    if (shift.breakTime && !manualBreaks[date]) {
-                        manualBreaks[date] = shift.breakTime;
+                    // break_timeがNULL、空文字列、undefinedの場合も処理する
+                    const breakTime = shift.breakTime;
+                    if (!manualBreaks[date] && breakTime !== null && breakTime !== undefined) {
+                        // 空文字列も含めて保存
+                        manualBreaks[date] = breakTime || '';
                     }
                 });
+                console.log('shiftsResult.results:', shiftsResult.results);
                 console.log('集約されたmanualBreaks:', manualBreaks);
 
                 // user_id=0のダミーレコードを除外してシフトデータを構築

--- a/my-shift-backend/src/index.ts
+++ b/my-shift-backend/src/index.ts
@@ -81,14 +81,31 @@ export default {
                 const { date, breaks, shortages } = await request.json<any>();
                 if (!date) return withCors(new Response('Date is required', { status: 400 }));
                 
-                if(breaks !== undefined) {
-                    await env.DB.prepare('INSERT OR REPLACE INTO manual_breaks (shift_date, break_text) VALUES (?, ?)').bind(date, breaks).run();
-                }
-                if(shortages !== undefined) {
-                    await env.DB.prepare('INSERT OR REPLACE INTO manual_shortages (shift_date, shortage_text) VALUES (?, ?)').bind(date, shortages).run();
-                }
+                try {
+                    if(breaks !== undefined) {
+                        const breaksResult = await env.DB.prepare('INSERT OR REPLACE INTO manual_breaks (shift_date, break_text) VALUES (?, ?)').bind(date, breaks || '').run();
+                        console.log('休憩時間保存結果:', breaksResult);
+                    }
+                    if(shortages !== undefined) {
+                        const shortagesResult = await env.DB.prepare('INSERT OR REPLACE INTO manual_shortages (shift_date, shortage_text) VALUES (?, ?)').bind(date, shortages || '').run();
+                        console.log('不足時間保存結果:', shortagesResult);
+                    }
 
-                return withCors(new Response(JSON.stringify({ success: true }), { status: 200 }));
+                    return withCors(new Response(JSON.stringify({ success: true, date, breaks, shortages }), { 
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    }));
+                } catch (dbError: any) {
+                    console.error('データベースエラー:', dbError);
+                    return withCors(new Response(JSON.stringify({ 
+                        success: false, 
+                        error: dbError.message,
+                        details: dbError.toString()
+                    }), { 
+                        status: 500,
+                        headers: { 'Content-Type': 'application/json' }
+                    }));
+                }
             
             } else if (url.pathname === '/api/login' && request.method === 'POST') {
                 const { username, password } = await request.json<any>();

--- a/my-shift-backend/src/index.ts
+++ b/my-shift-backend/src/index.ts
@@ -66,14 +66,26 @@ export default {
                 (shiftsResult.results || []).forEach((shift: any) => {
                     const date = shift.shiftDate as string;
                     // 同じ日付で最初に見つかったbreak_timeを使用（全レコードで同じ値のはず）
+                    // user_id=0のダミーレコードも含める
                     if (shift.breakTime && !manualBreaks[date]) {
                         manualBreaks[date] = shift.breakTime;
                     }
                 });
+                console.log('集約されたmanualBreaks:', manualBreaks);
+
+                // user_id=0のダミーレコードを除外してシフトデータを構築
+                const shiftsData = (shiftsResult.results || []).reduce<Record<string, any[]>>((acc, shift) => { 
+                    // user_id=0のダミーレコードは除外（休憩時間保存用）
+                    if (shift.userId === 0) return acc;
+                    const date = shift.shiftDate as string; 
+                    if (!acc[date]) acc[date] = []; 
+                    acc[date].push(shift); 
+                    return acc; 
+                }, {});
 
                 const data = {
                     users: usersResult.results,
-                    shifts: (shiftsResult.results || []).reduce<Record<string, any[]>>((acc, shift) => { const date = shift.shiftDate as string; if (!acc[date]) acc[date] = []; acc[date].push(shift); return acc; }, {}),
+                    shifts: shiftsData,
                     manualBreaks: manualBreaks,
                     manualShortages: (manualShortagesResult.results || []).reduce((acc, item: any) => { acc[item.shift_date as string] = item.shortage_text; return acc; }, {}),
                 };
@@ -101,8 +113,22 @@ export default {
                 try {
                     // 休憩時間は該当日付の全シフトレコードのbreak_timeカラムを更新
                     if(breaks !== undefined) {
-                        const breaksResult = await env.DB.prepare('UPDATE shifts SET break_time = ? WHERE shift_date = ?').bind(breaks || '', date).run();
-                        console.log('休憩時間保存結果:', breaksResult);
+                        // まず該当日付にuser_id=0のダミーレコードが存在するか確認
+                        const dummyRecord = await env.DB.prepare('SELECT * FROM shifts WHERE shift_date = ? AND user_id = 0').bind(date).first();
+                        
+                        if (dummyRecord) {
+                            // ダミーレコードが存在する場合、break_timeを更新
+                            await env.DB.prepare('UPDATE shifts SET break_time = ? WHERE shift_date = ? AND user_id = 0').bind(breaks || '', date).run();
+                            console.log('ダミーレコードの休憩時間を更新');
+                        } else {
+                            // ダミーレコードが存在しない場合、新規作成
+                            await env.DB.prepare('INSERT INTO shifts (user_id, shift_date, time, break_time) VALUES (0, ?, ?, ?)').bind(date, '', breaks || '').run();
+                            console.log('ダミーレコードを新規作成して休憩時間を保存');
+                        }
+                        
+                        // 該当日付の通常のシフトレコード（user_id != 0）のbreak_timeも更新
+                        const updateResult = await env.DB.prepare('UPDATE shifts SET break_time = ? WHERE shift_date = ? AND user_id != 0').bind(breaks || '', date).run();
+                        console.log('通常シフトレコードの休憩時間更新結果:', updateResult);
                     }
                     // 不足時間はmanual_shortagesテーブルに保存（shiftsテーブルに該当カラムがない場合）
                     if(shortages !== undefined) {

--- a/my-shift-backend/src/index.ts
+++ b/my-shift-backend/src/index.ts
@@ -47,17 +47,34 @@ export default {
                 `).bind(month);
                 
                 const usersStmt = env.DB.prepare('SELECT * FROM users ORDER BY id');
-                const manualBreaksStmt = env.DB.prepare("SELECT * FROM manual_breaks WHERE strftime('%Y-%m', shift_date) = ?").bind(month);
-                const manualShortagesStmt = env.DB.prepare("SELECT * FROM manual_shortages WHERE strftime('%Y-%m', shift_date) = ?").bind(month);
+                // manual_shortagesテーブルは存在する場合のみ取得
+                let manualShortagesStmt;
+                try {
+                    manualShortagesStmt = env.DB.prepare("SELECT * FROM manual_shortages WHERE strftime('%Y-%m', shift_date) = ?").bind(month);
+                } catch (e) {
+                    manualShortagesStmt = null;
+                }
 
-                const [shiftsResult, usersResult, manualBreaksResult, manualShortagesResult] = await Promise.all([
-                    shiftsStmt.all(), usersStmt.all(), manualBreaksStmt.all(), manualShortagesStmt.all()
+                const [shiftsResult, usersResult, manualShortagesResult] = await Promise.all([
+                    shiftsStmt.all(), 
+                    usersStmt.all(), 
+                    manualShortagesStmt ? manualShortagesStmt.all() : Promise.resolve({ results: [] })
                 ]);
+
+                // shiftsテーブルからbreak_timeを日付ごとに集約
+                const manualBreaks: Record<string, string> = {};
+                (shiftsResult.results || []).forEach((shift: any) => {
+                    const date = shift.shiftDate as string;
+                    // 同じ日付で最初に見つかったbreak_timeを使用（全レコードで同じ値のはず）
+                    if (shift.breakTime && !manualBreaks[date]) {
+                        manualBreaks[date] = shift.breakTime;
+                    }
+                });
 
                 const data = {
                     users: usersResult.results,
                     shifts: (shiftsResult.results || []).reduce<Record<string, any[]>>((acc, shift) => { const date = shift.shiftDate as string; if (!acc[date]) acc[date] = []; acc[date].push(shift); return acc; }, {}),
-                    manualBreaks: (manualBreaksResult.results || []).reduce((acc, item: any) => { acc[item.shift_date as string] = item.break_text; return acc; }, {}),
+                    manualBreaks: manualBreaks,
                     manualShortages: (manualShortagesResult.results || []).reduce((acc, item: any) => { acc[item.shift_date as string] = item.shortage_text; return acc; }, {}),
                 };
                 return withCors(new Response(JSON.stringify(data), { headers: { 'Content-Type': 'application/json' } }));
@@ -82,13 +99,21 @@ export default {
                 if (!date) return withCors(new Response('Date is required', { status: 400 }));
                 
                 try {
+                    // 休憩時間は該当日付の全シフトレコードのbreak_timeカラムを更新
                     if(breaks !== undefined) {
-                        const breaksResult = await env.DB.prepare('INSERT OR REPLACE INTO manual_breaks (shift_date, break_text) VALUES (?, ?)').bind(date, breaks || '').run();
+                        const breaksResult = await env.DB.prepare('UPDATE shifts SET break_time = ? WHERE shift_date = ?').bind(breaks || '', date).run();
                         console.log('休憩時間保存結果:', breaksResult);
                     }
+                    // 不足時間はmanual_shortagesテーブルに保存（shiftsテーブルに該当カラムがない場合）
                     if(shortages !== undefined) {
-                        const shortagesResult = await env.DB.prepare('INSERT OR REPLACE INTO manual_shortages (shift_date, shortage_text) VALUES (?, ?)').bind(date, shortages || '').run();
-                        console.log('不足時間保存結果:', shortagesResult);
+                        // まずテーブルの存在を確認してから保存
+                        try {
+                            const shortagesResult = await env.DB.prepare('INSERT OR REPLACE INTO manual_shortages (shift_date, shortage_text) VALUES (?, ?)').bind(date, shortages || '').run();
+                            console.log('不足時間保存結果:', shortagesResult);
+                        } catch (e: any) {
+                            // manual_shortagesテーブルが存在しない場合は無視
+                            console.warn('manual_shortagesテーブルが存在しません:', e.message);
+                        }
                     }
 
                     return withCors(new Response(JSON.stringify({ success: true, date, breaks, shortages }), { 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,82 @@
+const CACHE_NAME = '31shift-v1';
+const urlsToCache = [
+  '/',
+  '/index.html',
+  '/css/style.css',
+  '/img/icon.png',
+  'https://cdn.tailwindcss.com',
+  'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css',
+  'https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js',
+  'https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js'
+];
+
+// インストール時の処理
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then((cache) => {
+        console.log('キャッシュを開きました');
+        return cache.addAll(urlsToCache);
+      })
+      .catch((error) => {
+        console.error('キャッシュの追加に失敗しました:', error);
+      })
+  );
+  self.skipWaiting();
+});
+
+// アクティベート時の処理
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) => {
+      return Promise.all(
+        cacheNames.map((cacheName) => {
+          if (cacheName !== CACHE_NAME) {
+            console.log('古いキャッシュを削除:', cacheName);
+            return caches.delete(cacheName);
+          }
+        })
+      );
+    })
+  );
+  return self.clients.claim();
+});
+
+// フェッチ時の処理（ネットワーク優先、フォールバックでキャッシュ）
+self.addEventListener('fetch', (event) => {
+  // APIリクエストは常にネットワークを使用
+  if (event.request.url.includes('my-shift-backend.tamago-2483.workers.dev')) {
+    event.respondWith(
+      fetch(event.request)
+        .catch(() => {
+          // ネットワークエラー時はキャッシュを返さず、エラーを返す
+          return new Response(
+            JSON.stringify({ error: 'オフラインです。ネットワーク接続を確認してください。' }),
+            {
+              status: 503,
+              headers: { 'Content-Type': 'application/json' }
+            }
+          );
+        })
+    );
+    return;
+  }
+
+  // その他のリクエストはネットワーク優先、フォールバックでキャッシュ
+  event.respondWith(
+    fetch(event.request)
+      .then((response) => {
+        // レスポンスをクローンしてキャッシュに保存
+        const responseToCache = response.clone();
+        caches.open(CACHE_NAME).then((cache) => {
+          cache.put(event.request, responseToCache);
+        });
+        return response;
+      })
+      .catch(() => {
+        // ネットワークエラー時はキャッシュから取得
+        return caches.match(event.request);
+      })
+  );
+});
+

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,13 +1,10 @@
 const CACHE_NAME = '31shift-v1';
+// ローカルリソースのみキャッシュ（CDNリソースは除外）
 const urlsToCache = [
   '/',
   '/index.html',
   '/css/style.css',
-  '/img/icon.png',
-  'https://cdn.tailwindcss.com',
-  'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css',
-  'https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js',
-  'https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js'
+  '/img/icon.png'
 ];
 
 // インストール時の処理
@@ -16,7 +13,14 @@ self.addEventListener('install', (event) => {
     caches.open(CACHE_NAME)
       .then((cache) => {
         console.log('キャッシュを開きました');
-        return cache.addAll(urlsToCache);
+        // ローカルリソースのみキャッシュ（エラーを無視して続行）
+        return Promise.allSettled(
+          urlsToCache.map(url => 
+            cache.add(url).catch(err => {
+              console.warn(`キャッシュに追加できませんでした: ${url}`, err);
+            })
+          )
+        );
       })
       .catch((error) => {
         console.error('キャッシュの追加に失敗しました:', error);
@@ -66,16 +70,30 @@ self.addEventListener('fetch', (event) => {
   event.respondWith(
     fetch(event.request)
       .then((response) => {
-        // レスポンスをクローンしてキャッシュに保存
-        const responseToCache = response.clone();
-        caches.open(CACHE_NAME).then((cache) => {
-          cache.put(event.request, responseToCache);
-        });
+        // ローカルリソースのみキャッシュに保存（CDNリソースは除外）
+        const url = new URL(event.request.url);
+        const isLocalResource = url.origin === self.location.origin;
+        
+        if (isLocalResource && response.status === 200) {
+          // レスポンスをクローンしてキャッシュに保存
+          const responseToCache = response.clone();
+          caches.open(CACHE_NAME).then((cache) => {
+            cache.put(event.request, responseToCache).catch(err => {
+              console.warn('キャッシュの保存に失敗しました:', err);
+            });
+          });
+        }
         return response;
       })
       .catch(() => {
-        // ネットワークエラー時はキャッシュから取得
-        return caches.match(event.request);
+        // ネットワークエラー時はキャッシュから取得（ローカルリソースのみ）
+        const url = new URL(event.request.url);
+        const isLocalResource = url.origin === self.location.origin;
+        if (isLocalResource) {
+          return caches.match(event.request);
+        }
+        // CDNリソースの場合はエラーをそのまま返す
+        return new Response('ネットワークエラー', { status: 503 });
       })
   );
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,10 @@
+{
+  // Cloudflare Workers Versions (build) config for static asset upload
+  "name": "31shiftplus",
+  "compatibility_date": "2025-11-06",
+  "assets": {
+    // Upload all files in the repository as static assets
+    "directory": "./"
+  }
+}
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds PWA (manifest + service worker), introduces break-time parsing/visualization and unified storage, and improves bulk shift UX with safer saves and refresh.
> 
> - **PWA / Deployment**
>   - Add PWA meta tags, `manifest.json`, and register a `service-worker.js` (network-first, cache local assets).
>   - Add `wrangler.jsonc` for static asset upload via Cloudflare Workers Versions.
> - **Frontend** (`index.html`)
>   - Viewport tweak and input font-size on focus to prevent mobile zoom.
>   - Parse and normalize break times (supports ranges like `17:00-18:00` and legacy formats) via `parseBreakTime`.
>   - Apply break-time to daily chart by splitting bars; tooltip shows worked duration.
>   - Bulk table: normalize/validate inputs (including breaks), de-dup rapid saves, allow Enter-to-save on mobile, and force-refresh month data after save.
>   - Improve user sorting and minor accessibility/focus handling.
> - **Backend** (`my-shift-backend/src/index.ts`)
>   - `/api/data`: order results, `COALESCE` user fields, aggregate `break_time` per date into `manualBreaks`, and exclude `user_id=0` dummy rows from `shifts`; fetch `manual_shortages` only if table exists.
>   - `/api/update-manual-data`: store break-time in `shifts.break_time` (create/update `user_id=0` dummy row and propagate to all rows for the date); optionally upsert shortages; structured success/error JSON.
>   - `/api/update-shift`: unchanged behavior with explicit delete/insert path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efb8cdd8ab6ce53030de779929dd1976f941d3a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->